### PR TITLE
Automatically go to bottom of goal buffer when it is refreshed

### DIFF
--- a/autoload/coquille/IDE.vim
+++ b/autoload/coquille/IDE.vim
@@ -499,6 +499,10 @@ function! s:IDE.refreshGoal() abort
   for bufnr in self.GoalBuffers
     call deletebufline(bufnr, 1, '$')
     call setbufline(bufnr, 1, self.goal_message)
+    let current_winnr = winnr()
+    let goal_winnr = bufwinnr(bufnr)
+    exe goal_winnr 'windo normal! G'
+    exe current_winnr 'wincmd w'
   endfor
 endfunction
 


### PR DESCRIPTION
Currently, when the goal buffer is refreshed, coqpit.vim automatically sets position to the top of the goal buffer (I am not aware of codes explicitly doing this, so perhaps this is the default behavior from vim?). But when the goal buffer is too large to be completely shown in its window, I have to manually switch to and scroll the window to see the goal at the bottom. This operation has to be performed whenever the goal buffer is refreshed, i.e. when moving with CoqNext/CoqBack/CoqToCursor, which can be quite annoying.

This PR adds the functionality of automatically focusing the bottom of the goal buffer in its window, whenever it is refreshed. This behavior is based on the following observation:

> The goal should be the most important part of the goal buffer, and is viewed most frequently. Besides, newly generated premises tend to be used immediately, and older premises are less often used than newer ones.

So this PR should reduce the need of manually scrolling the goal window.

However, I am not a coq expert, neither use it heavily. So if the above observation is incorrect, please point it out. AFAIK alternative options include:

1. Make the behavior a user option

2. Remember the cursor position and restore it on goal buffer refreshment. This sounds good, but I am not sure about the exact behavior.

Also I am not very familiar with vim internals, so perhaps there is a smarter way to implement this PR. Please point it out if you have any thoughts.

And lastly, I am not aware of something like `CONTRIBUTING.md', if there are any requirements for PRs please inform me.